### PR TITLE
Add a github workflow to automatically build github pages

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,44 @@
+name: Publish docs via GitHub Pages
+on:
+  push:
+    branches:
+      - master
+      - test # For test
+  workflow_dispatch: #Allows for manual triggering
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout commits
+        uses: actions/checkout@v2
+      - name: Download latest version of Guidelines
+        uses: actions/checkout@v2
+        with:
+          repository: segmonto/guidelines
+          path: ./git-guidelines
+      - name: Copy content
+        run: |
+          ls  #Show the content
+          rm ./docs/gd/**/*.md
+          cp ./git-guidelines/lines/**/*.md ./docs/gd/gdL
+          cp ./git-guidelines/zones/**/*.md ./docs/gd/gdZ
+          ls ./docs/gd/gdL
+          python scripts/copyImages.py # Put the images in directories
+          python scripts/update-guidelines.py # Update the menu
+          rm -rf ./git-guidelines
+      - name: Commit files
+        if: github.ref == 'refs/heads/master' # Change if branch name changes
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add ./docs mkdocs.yml
+          git commit -m "[Automatic] Update Guidelines" || echo "Nothing to update"
+          git push || echo "Nothing to push"
+      - name: Deploy docs
+        if: github.ref == 'refs/heads/master' # Change if branch name changes
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFIG_FILE: mkdocs.yml
+          REQUIREMENTS: requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs-material
+mkdocs-git-revision-date-localized-plugin
+pymdown-extensions 

--- a/scripts/copyImages.py
+++ b/scripts/copyImages.py
@@ -1,0 +1,16 @@
+from glob import glob
+import os
+import shutil
+
+def func(unixPath="./lines/**/*", targetDir="./docs/gd/gdL/"):
+    for file in glob(unixPath):
+        if file.endswith(".md"):
+            continue
+        tgt = targetDir+os.path.dirname(file).split("/")[-1]
+        os.makedirs(tgt, exist_ok=True)
+        shutil.copyfile(file, f"{tgt}/{os.path.basename(file)}")
+
+
+
+func("./git-guidelines/zones/**/*", targetDir="./docs/gd/gdZ/")
+func("./git-guidelines/lines/**/*", targetDir="./docs/gd/gdL/")

--- a/scripts/update-guidelines.py
+++ b/scripts/update-guidelines.py
@@ -1,0 +1,37 @@
+import yaml
+import glob
+import os.path
+
+with open("mkdocs.yml") as f:
+    yml = yaml.load(f)
+
+
+def replace(dic, keys, new_val):
+    for val in dic:
+        if keys and keys[0] in val:
+            k = keys.pop(0)
+            if keys:
+                replace(val[k], keys, new_val)
+            else:
+                val[k] = new_val
+
+
+replace(yml["nav"], ["Guidelines", "Zones"], [
+    {
+        os.path.basename(filename.replace(".md", "")): filename.replace("./docs/", "")
+    }
+    for filename in sorted(glob.glob("./docs/gd/gdZ/*.md"))
+])
+
+replace(yml["nav"], ["Guidelines", "Lines"], [
+    {
+        os.path.basename(filename.replace(".md", "")): filename.replace("./docs/", "")
+    }
+    for filename in sorted(glob.glob("./docs/gd/gdL/*.md"))
+])
+
+print(yml)
+
+
+with open("mkdocs.yml", "w") as f:
+	f.write(yaml.dump(yml))


### PR DESCRIPTION
This should fix #1 and #2 by providing a simple way to rebuild entirely the whole website.

See https://ponteineptique.github.io/SegmOnto.github.io/gd/gdZ/MarginTextZone/

This:
1. Fetches the guidelines master branch
2. Copy the files where they belong, including images which were bugging until now.
3. Commit to the master branch the changes
4. Build the GH Pages with mkdocs
5. Make your life easier

This only triggers on branch master and test, and the branch test does not deploy the changes (it only "builds")